### PR TITLE
Rendering loop rewrite (#339)

### DIFF
--- a/src/platform/core/include/platform/device/ogl_video_device.hpp
+++ b/src/platform/core/include/platform/device/ogl_video_device.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <array>
 #include <nba/device/video_device.hpp>
 #include <GL/glew.h>
 #include <platform/config.hpp>
@@ -27,7 +28,9 @@ struct OGLVideoDevice : VideoDevice {
   void ReloadConfig();
 
 private:
+  void UpdateTextures();
   void CreateShaderPrograms();
+  void UpdateShaderUniforms();
   void ReleaseShaderPrograms();
 
   auto CompileShader(
@@ -40,6 +43,19 @@ private:
     char const* fragment_src
   ) -> std::pair<bool, GLuint>;
 
+  static constexpr size_t input_index       = 0;
+  static constexpr size_t output_index      = 1;
+  static constexpr size_t history_index     = 2;
+  static constexpr size_t xbrz_output_index = 3;
+
+  struct ShaderPass {
+    GLuint program = 0;
+    struct {
+      std::vector<GLuint> inputs = {input_index};
+      GLuint output = output_index;
+    } textures = {};
+  };
+
   int view_x = 0;
   int view_y = 0;
   int view_width  = 1;
@@ -49,10 +65,9 @@ private:
   GLuint quad_vao;
   GLuint quad_vbo;
   GLuint fbo;
-  GLuint texture[4];
-  std::vector<GLuint> programs;
-  GLenum texture_filter = GL_NEAREST;
-  bool texture_filter_invalid = false;
+  std::array<GLuint, 4> textures        = {};
+  std::vector<ShaderPass> shader_passes = {};
+  GLint texture_filter = GL_NEAREST;
 
   std::shared_ptr<PlatformConfig> config;
 };

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -5,6 +5,7 @@
  * Refer to the included LICENSE file.
  */
 
+#include <array>
 #include <filesystem>
 #include <fmt/format.h>
 #include <fstream>
@@ -22,14 +23,15 @@ using Video = nba::PlatformConfig::Video;
 
 namespace nba {
 
-static const float kQuadVertices[] = {
+static constexpr int gba_screen_width  = 240;
+static constexpr int gba_screen_height = 160;
+
+static constexpr std::array<GLfloat, 4 * 4> kQuadVertices = {
 // position | UV coord
-  -1,  1,     0, 1,
-   1,  1,     1, 1,
-   1, -1,     1, 0,
-   1, -1,     1, 0,
   -1, -1,     0, 0,
-  -1,  1,     0, 1
+   1, -1,     1, 0,
+  -1,  1,     0, 1,
+   1,  1,     1, 1
 };
 
 OGLVideoDevice::OGLVideoDevice(std::shared_ptr<PlatformConfig> config) : config(config) {
@@ -40,7 +42,7 @@ OGLVideoDevice::~OGLVideoDevice() {
   glDeleteVertexArrays(1, &quad_vao);
   glDeleteBuffers(1, &quad_vbo);
   glDeleteFramebuffers(1, &fbo);
-  glDeleteTextures(4, texture);
+  glDeleteTextures(textures.size(), textures.data());
 }
 
 void OGLVideoDevice::Initialize() {
@@ -51,21 +53,15 @@ void OGLVideoDevice::Initialize() {
   glGenBuffers(1, &quad_vbo);
   glBindVertexArray(quad_vao);
   glBindBuffer(GL_ARRAY_BUFFER, quad_vbo);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(kQuadVertices), kQuadVertices, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
-  glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
+  glBufferData(GL_ARRAY_BUFFER, sizeof(kQuadVertices), kQuadVertices.data(), GL_STATIC_DRAW);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), (void*)0);
+  glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), (void*)(2 * sizeof(GLfloat)));
   glEnableVertexAttribArray(0);
   glEnableVertexAttribArray(1);
 
   // Create three textures and a framebuffer for postprocessing.
-  glEnable(GL_TEXTURE_2D);
   glGenFramebuffers(1, &fbo);
-  glGenTextures(4, texture);
-  for(int i = 0; i < 4; i++) {
-    glBindTexture(GL_TEXTURE_2D, texture[i]);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  }
+  glGenTextures(textures.size(), textures.data());
 
   glClearColor(0, 0, 0, 1);
   glClear(GL_COLOR_BUFFER_BIT);
@@ -74,15 +70,61 @@ void OGLVideoDevice::Initialize() {
 }
 
 void OGLVideoDevice::ReloadConfig() {
-  texture_filter_invalid = true;
-
   if(config->video.filter == Video::Filter::Linear) {
     texture_filter = GL_LINEAR;
   } else {
     texture_filter = GL_NEAREST;
   }
 
+  UpdateTextures();
   CreateShaderPrograms();
+}
+
+void OGLVideoDevice::UpdateTextures() {
+  constexpr auto set_texture_params = [=](GLint tex_filter) {
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, tex_filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, tex_filter);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  };
+
+  // Alternating input sampler and output framebuffer attachment.
+  for(const auto texture : {textures[input_index], textures[output_index]}) {
+    glBindTexture(GL_TEXTURE_2D, texture);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, gba_screen_width,
+                 gba_screen_height, 0, GL_BGRA, GL_UNSIGNED_BYTE, nullptr);
+
+    set_texture_params(texture_filter);
+  }
+
+  /* Depending on the order of shaders, xBRZ scaler may need an intermediate
+   * output-sized texture, to be sampled in the LCD ghosting effect shader.
+   * This improves the look of the latter.
+   */
+  const bool xbrz_ghosting =
+    config->video.filter == Video::Filter::xBRZ && config->video.lcd_ghosting;
+  if(config->video.lcd_ghosting) {
+    const GLsizei texture_width  = xbrz_ghosting ? view_width : gba_screen_width;
+    const GLsizei texture_height = xbrz_ghosting ? view_height : gba_screen_height;
+
+    glBindTexture(GL_TEXTURE_2D, textures[history_index]);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, texture_width, texture_height, 0,
+                 GL_BGRA, GL_UNSIGNED_BYTE, nullptr);
+
+    set_texture_params(GL_NEAREST);
+  }
+
+  if(xbrz_ghosting) {
+    glBindTexture(GL_TEXTURE_2D, textures[xbrz_output_index]);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, view_width, view_height, 0,
+                 GL_BGRA, GL_UNSIGNED_BYTE, nullptr);
+
+    set_texture_params(GL_NEAREST);
+  }
 }
 
 void OGLVideoDevice::CreateShaderPrograms() {
@@ -90,33 +132,21 @@ void OGLVideoDevice::CreateShaderPrograms() {
 
   ReleaseShaderPrograms();
 
-  // xBRZ freescale upsampling filter (two passes)
-  if(video.filter == Video::Filter::xBRZ) {
-    auto [success0, program0] = CompileProgram(xbrz0_vert, xbrz0_frag);
-    auto [success1, program1] = CompileProgram(xbrz1_vert, xbrz1_frag);
-    
-    if(success0 && success1) {
-      programs.push_back(program0);
-      programs.push_back(program1);
-    } else {
-      if(success0) glDeleteProgram(program0);
-      if(success1) glDeleteProgram(program1);
-    }
-  }
-
+  // TODO: Switch to designated initializers after moving to C++20.
   // Color correction pass
   switch(video.color) {
+    case Video::Color::No: break;
     case Video::Color::higan: {
       auto [success, program] = CompileProgram(color_higan_vert, color_higan_frag);
       if(success) {
-        programs.push_back(program);
+        shader_passes.push_back({program});
       }
       break;
     }
     case Video::Color::AGB: {
       auto [success, program] = CompileProgram(color_agb_vert, color_agb_frag);
       if(success) {
-        programs.push_back(program);
+        shader_passes.push_back({program});
       }
       break;
     }
@@ -126,42 +156,80 @@ void OGLVideoDevice::CreateShaderPrograms() {
   if(video.lcd_ghosting) {
     auto [success, program] = CompileProgram(lcd_ghosting_vert, lcd_ghosting_frag);
     if(success) {
-      programs.push_back(program);
+      const GLuint input_texture = video.filter == Video::Filter::xBRZ ? xbrz_output_index : input_index;
+      shader_passes.push_back({program, {{input_texture, history_index}}});
     }
   }
 
   // Output pass (final)
-  auto [success, program] = CompileProgram(output_vert, output_frag);
-  if(success) {
-    programs.push_back(program);
+  switch(video.filter) {
+    // xBRZ freescale upsampling filter (two passes)
+    case Video::Filter::xBRZ: {
+      auto [success0, program0] = CompileProgram(xbrz0_vert, xbrz0_frag);
+      auto [success1, program1] = CompileProgram(xbrz1_vert, xbrz1_frag);
+
+      if(success0 && success1) {
+        if(video.lcd_ghosting) {
+          shader_passes.insert(std::prev(shader_passes.end()), {program0});
+          shader_passes.insert(
+            std::prev(shader_passes.end()),
+            {program1, {{output_index, input_index}, xbrz_output_index}});
+        } else {
+          shader_passes.push_back({program0});
+          shader_passes.push_back({program1, {{output_index, input_index}}});
+        }
+      } else {
+        if(success0) glDeleteProgram(program0);
+        if(success1) glDeleteProgram(program1);
+      }
+      break;
+    }
+    // Plain linear/nearest-interpolated output.
+    case Video::Filter::Nearest:
+    case Video::Filter::Linear: {
+      auto [success, program] = CompileProgram(output_vert, output_frag);
+      if(success) {
+        shader_passes.push_back({program});
+      }
+      break;
+    }
   }
 
-  // Set constant shader uniforms.
-  for(auto program : programs) {
-    glUseProgram(program);
+  UpdateShaderUniforms();
+}
 
-    auto screen_map = glGetUniformLocation(program, "u_screen_map");
-    if(screen_map != -1) {
-      glUniform1i(screen_map, 0);
+void OGLVideoDevice::UpdateShaderUniforms() {
+  // Set constant shader uniforms.
+  for(const auto& shader_pass : shader_passes) {
+    glUseProgram(shader_pass.program);
+
+    const auto input_map = glGetUniformLocation(shader_pass.program, "u_input_map");
+    if(input_map != -1) {
+      glUniform1i(input_map, 0);
     }
 
-    auto history_map = glGetUniformLocation(program, "u_history_map");
+    const auto history_map = glGetUniformLocation(shader_pass.program, "u_history_map");
     if(history_map != -1) {
       glUniform1i(history_map, 1);
     }
 
-    auto source_map = glGetUniformLocation(program, "u_source_map");
-    if(source_map != -1) {
-      glUniform1i(source_map, 2);
+    const auto info_map = glGetUniformLocation(shader_pass.program, "u_info_map");
+    if(info_map != -1) {
+      glUniform1i(info_map, 1);
+    }
+
+    const auto output_size = glGetUniformLocation(shader_pass.program, "u_output_size");
+    if(output_size != -1) {
+      glUniform2f(output_size, view_width, view_height);
     }
   }
 }
 
 void OGLVideoDevice::ReleaseShaderPrograms() {
-  for(auto program : programs) {   
-    glDeleteProgram(program);
+  for(const auto& shader_pass : shader_passes) {
+    glDeleteProgram(shader_pass.program);
   }
-  programs.clear();
+  shader_passes.clear();
 }
 
 auto OGLVideoDevice::CompileShader(
@@ -218,20 +286,8 @@ void OGLVideoDevice::SetViewport(int x, int y, int width, int height) {
   view_width  = width;
   view_height = height;
 
-  for(int i = 0; i < 3; i++) {
-    glBindTexture(GL_TEXTURE_2D, texture[i]);
-    glTexImage2D(
-      GL_TEXTURE_2D,
-      0,
-      GL_RGBA,
-      view_width,
-      view_height,
-      0,
-      GL_BGRA,
-      GL_UNSIGNED_BYTE,
-      nullptr
-    );
-  }
+  UpdateTextures();
+  UpdateShaderUniforms();
 }
 
 void OGLVideoDevice::SetDefaultFBO(GLuint fbo) {
@@ -239,63 +295,64 @@ void OGLVideoDevice::SetDefaultFBO(GLuint fbo) {
 }
 
 void OGLVideoDevice::Draw(u32* buffer) {
-  int target = 0;
-
   // Update and bind LCD screen texture
   glActiveTexture(GL_TEXTURE0);
-  glBindTexture(GL_TEXTURE_2D, texture[3]);
-  glTexImage2D(
-    GL_TEXTURE_2D, 0, GL_RGBA, 240, 160, 0, GL_BGRA, GL_UNSIGNED_BYTE, buffer
-  );
-  if(texture_filter_invalid) {
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texture_filter);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texture_filter);
-    texture_filter_invalid = false;
-  }
+  glBindTexture(GL_TEXTURE_2D, textures[input_index]);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, gba_screen_width, gba_screen_height,
+                  GL_BGRA, GL_UNSIGNED_BYTE, buffer);
 
-  // Bind LCD history map
-  glActiveTexture(GL_TEXTURE1);
-  glBindTexture(GL_TEXTURE_2D, texture[2]);
-
-  // Bind LCD source map
-  glActiveTexture(GL_TEXTURE2);
-  glBindTexture(GL_TEXTURE_2D, texture[3]);
-
-  auto program_count = programs.size();
-
-  glViewport(0, 0, view_width, view_height);
   glBindVertexArray(quad_vao);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
 
-  if(program_count <= 2) {
-    target = 2;
+  for(auto shader_pass = shader_passes.begin(); shader_pass != shader_passes.end(); ++shader_pass) {
+    glUseProgram(shader_pass->program);
+
+    if(shader_pass == std::prev(shader_passes.end())) {
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, default_fbo);
+      glViewport(view_x, view_y, view_width, view_height);
+    } else {
+      glActiveTexture(GL_TEXTURE0);
+      glBindTexture(GL_TEXTURE_2D, textures[shader_pass->textures.output]);
+
+      GLint output_width  = 0;
+      GLint output_height = 0;
+      glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &output_width);
+      glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &output_height);
+
+      glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textures[shader_pass->textures.output], 0);
+
+      glViewport(0, 0, output_width, output_height);
+    }
+
+    for(size_t i = 0; i < shader_pass->textures.inputs.size(); ++i) {
+      glActiveTexture(GL_TEXTURE0 + i);
+      glBindTexture(GL_TEXTURE_2D, textures[shader_pass->textures.inputs[i]]);
+    }
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    std::swap(textures[input_index], textures[output_index]);
   }
 
-  for(int i = 0; i < program_count; i++) {
-    glUseProgram(programs[i]);
-
-    if(i == program_count - 1) {
-      glViewport(view_x, view_y, view_width, view_height);
-      glBindFramebuffer(GL_FRAMEBUFFER, default_fbo);
+  if(config->video.lcd_ghosting) {
+    GLint copy_area_x        = 0;
+    GLint copy_area_y        = 0;
+    GLsizei copy_area_width  = gba_screen_width;
+    GLsizei copy_area_height = gba_screen_height;
+    if(config->video.filter == Video::Filter::xBRZ) {
+      copy_area_x      = view_x;
+      copy_area_y      = view_y;
+      copy_area_width  = view_width;
+      copy_area_height = view_height;
     } else {
-      glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture[target], 0);
+      glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+      glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textures[output_index], 0);
     }
 
-    glDrawArrays(GL_TRIANGLES, 0, 6);
-
-    // Output of the current pass is the input for the next pass.
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, texture[target]);
-
-    if(i == program_count - 3) {
-      /* The next pass is the next-to-last pass, before we render to screen.
-       * Render that pass into a separate texture, so that it can be 
-       * used in the next frame to calculate LCD ghosting.
-       */
-      target = 2;
-    } else {
-      target ^= 1;
-    }
+    glBindTexture(GL_TEXTURE_2D, textures[history_index]);
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, copy_area_x, copy_area_y, copy_area_width, copy_area_height);
   }
 }
 

--- a/src/platform/core/src/device/shader/color_agb.glsl.hpp
+++ b/src/platform/core/src/device/shader/color_agb.glsl.hpp
@@ -42,10 +42,10 @@ constexpr auto color_agb_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map;
+  uniform sampler2D u_input_map;
 
   void main() {
-    vec4 screen = pow(texture(u_screen_map, v_uv), vec4(target_gamma + darken_screen)).rgba;
+    vec4 screen = pow(texture(u_input_map, v_uv), vec4(target_gamma + darken_screen)).rgba;
     vec4 avglum = vec4(0.5);
     screen = mix(screen, avglum, (1.0 - contrast));
      

--- a/src/platform/core/src/device/shader/color_higan.glsl.hpp
+++ b/src/platform/core/src/device/shader/color_higan.glsl.hpp
@@ -12,10 +12,10 @@ constexpr auto color_higan_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map;
+  uniform sampler2D u_input_map;
 
   void main() {
-    vec4 color = texture(u_screen_map, v_uv);
+    vec4 color = texture(u_input_map, v_uv);
 
     color.rgb = pow(color.rgb, vec3(4.0));
 

--- a/src/platform/core/src/device/shader/common.glsl.hpp
+++ b/src/platform/core/src/device/shader/common.glsl.hpp
@@ -20,3 +20,17 @@ constexpr auto common_vert = R"(
     gl_Position = vec4(position, 0.0, 1.0);
   }
 )";
+
+constexpr auto common_flip_vert = R"(
+  #version 330 core
+
+  layout(location = 0) in vec2 position;
+  layout(location = 1) in vec2 uv;
+
+  out vec2 v_uv;
+
+  void main() {
+    v_uv = vec2(uv.x, 1.0 - uv.y);
+    gl_Position = vec4(position, 0.0, 1.0);
+  }
+)";

--- a/src/platform/core/src/device/shader/lcd_ghosting.glsl.hpp
+++ b/src/platform/core/src/device/shader/lcd_ghosting.glsl.hpp
@@ -18,11 +18,11 @@ constexpr auto lcd_ghosting_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map;
+  uniform sampler2D u_input_map;
   uniform sampler2D u_history_map;
 
   void main() {
-    vec4 color_a = texture(u_screen_map, v_uv);
+    vec4 color_a = texture(u_input_map, v_uv);
     vec4 color_b = texture(u_history_map, v_uv);
     frag_color = mix(color_a, color_b, 0.5);
   }

--- a/src/platform/core/src/device/shader/output.glsl.hpp
+++ b/src/platform/core/src/device/shader/output.glsl.hpp
@@ -9,7 +9,7 @@
 
 #include "device/shader/common.glsl.hpp"
 
-constexpr auto output_vert = common_vert;
+constexpr auto output_vert = common_flip_vert;
 
 constexpr auto output_frag = R"(
   #version 330 core
@@ -18,9 +18,9 @@ constexpr auto output_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map;
+  uniform sampler2D u_input_map;
 
   void main() {
-    frag_color = texture(u_screen_map, vec2(v_uv.x, 1.0 - v_uv.y));
+    frag_color = texture(u_input_map, v_uv);
   }
 )";

--- a/src/platform/core/src/device/shader/xbrz.glsl.hpp
+++ b/src/platform/core/src/device/shader/xbrz.glsl.hpp
@@ -52,9 +52,9 @@ constexpr auto xbrz0_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_source_map;
+  uniform sampler2D u_input_map;
 
-  #define u_source_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
+  #define u_input_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
 
   #define BLEND_NONE 0
   #define BLEND_NORMAL 1
@@ -98,7 +98,7 @@ constexpr auto xbrz0_frag = R"(
   #define eq(a,b)  (a == b)
   #define neq(a,b) (a != b)
 
-  #define P(x,y) texture(u_source_map, coord + u_source_size.zw * vec2(x, y)).rgb
+  #define P(x,y) texture(u_input_map, coord + u_input_size.zw * vec2(x, y)).rgb
 
 void main() {
   //---------------------------------------
@@ -108,8 +108,8 @@ void main() {
   //                       x|G|H|I|x
   //                       -|x|x|x|-
 
-  vec2 pos = fract(v_uv * u_source_size.xy) - vec2(0.5, 0.5);
-  vec2 coord = v_uv - pos * u_source_size.zw;
+  vec2 pos = fract(v_uv * u_input_size.xy) - vec2(0.5, 0.5);
+  vec2 coord = v_uv - pos * u_input_size.zw;
 
   vec3 A = P(-1,-1);
   vec3 B = P( 0,-1);
@@ -268,24 +268,7 @@ frag_color /= 255.0;
 }
 )";
 
-constexpr auto xbrz1_vert = R"(
-  #version 330 core
-
-  layout(location = 0) in vec2 position;
-  layout(location = 1) in vec2 uv;
-
-  out vec2 v_uv;
-  out vec4 u_screen_size;
-
-  uniform sampler2D u_screen_map;
-
-  void main() {
-    v_uv = uv;
-    u_screen_size.xy = textureSize(u_screen_map, 0);
-    u_screen_size.zw = 1.0 / textureSize(u_screen_map, 0);
-    gl_Position = vec4(position, 0.0, 1.0);
-  }
-)";
+constexpr auto xbrz1_vert = common_flip_vert;
 
 constexpr auto xbrz1_frag = R"(
   #version 330 core
@@ -293,12 +276,12 @@ constexpr auto xbrz1_frag = R"(
   layout(location = 0) out vec4 frag_color;
 
   in vec2 v_uv;
-  in vec4 u_screen_size;
 
-  uniform sampler2D u_screen_map; // info texture
-  uniform sampler2D u_source_map; // LCD texture
+  uniform sampler2D u_input_map; // LCD texture
+  uniform sampler2D u_info_map; // info texture
+  uniform vec2 u_output_size;
 
-  #define u_source_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
+  #define u_input_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
 
   #define BLEND_NONE 0
   #define BLEND_NORMAL 1
@@ -342,7 +325,7 @@ constexpr auto xbrz1_frag = R"(
   #define eq(a,b)  (a == b)
   #define neq(a,b) (a != b)
 
-  #define P(x,y) texture(u_source_map, coord + u_source_size.zw * vec2(x, y)).rgb
+  #define P(x,y) texture(u_input_map, coord + u_input_size.zw * vec2(x, y)).rgb
 
   void main() {
    //---------------------------------------
@@ -350,9 +333,9 @@ constexpr auto xbrz1_frag = R"(
     //                      D|E|F
     //                      -|H|-
 
-    vec2 scale = u_screen_size.xy * u_source_size.zw;
-    vec2 pos = fract(v_uv * u_source_size.xy) - vec2(0.5, 0.5);
-    vec2 coord = v_uv - pos * u_source_size.zw;
+    vec2 scale = u_output_size.xy * u_input_size.zw;
+    vec2 pos = fract(v_uv * u_input_size.xy) - vec2(0.5, 0.5);
+    vec2 coord = v_uv - pos * u_input_size.zw;
 
     vec3 B = P( 0,-1);
     vec3 D = P(-1, 0);
@@ -360,7 +343,7 @@ constexpr auto xbrz1_frag = R"(
     vec3 F = P( 1, 0);
     vec3 H = P( 0, 1);
 
-    vec4 info = floor(texture(u_screen_map, coord) * 255.0 + 0.5);
+    vec4 info = floor(texture(u_info_map, coord) * 255.0 + 0.5);
 
     // info Mapping: x|y|
     //               w|z|


### PR DESCRIPTION
* PlatformCore: Remove erroneus OpenGL call

* PlatformCore: Add GBA screen size constants

* PlatformCore: Switch to drawing a triangle strip

Vertices' origin at the bottom left, CCW order.

* PlatformCore: Cleanup types

* PlatformCore: Extract setting texture parameters

Also set texture wrapping parameters to eliminate artifacts on the edges of the output image when using linear sampling.

* PlatformCore: Extract setting shader uniforms

* PlatformCore: Add output size shader uniform

And use it in xBRZ shader.

* PlatformCore: Rename u_screen_map into u_input_map

* PlatformCore: Add flipped UV generic vertex shader

* PlatformCore: Adjust setting viewport

* PlatformCore: Upload texture data via glTexSubImage

* PlatformCore: Rewrite rendering loop

Introduce ShaderPass object, which holds shader program and input/output texture indices.